### PR TITLE
Add types export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
+      "import": "./dist/esm/index.js",
+      "types": "./dist/imgproxy-node.d.ts"
     }
   },
   "license": "MIT",


### PR DESCRIPTION
Types are not resolved properly in Typescript, because the definition file is not included in exports.

This PR should fix #1.